### PR TITLE
Implementation for offline MDS cluster 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Development of custom cms EXO PAG nanoAOD format
 
 ## Setup in CMSSW
 ```
-cmsrel CMSSW_15_0_0_pre3
-cd CMSSW_15_0_0_pre3/src
+cmsrel CMSSW_15_1_0_pre2
+cd CMSSW_15_1_0_pre2/src
 cmsenv
 git cms-init
 mkdir PhysicsTools
@@ -13,14 +13,6 @@ cd PhysicsTools
 git clone git@github.com:kerstinlovisa/EXOnanoAOD.git
 scram b -j
 ```
-## Enable MDSnano tables
-Before EXOnanoAOD is integrated into cmssw, we need the following commit to include the simple table to produce new data-type
-```
-git remote add kakwok git@github.com:kakwok/cmssw.git 
-git cms-addpkg PhysicsTools/NanoAOD
-git cherry-pick fb5f0b9 
-```
-Then un-comment the line in `custom_exo_cff.py`
 
 # Setup
 Please include your customizations as python scripts under `python`, and if you need a custom producer add it under `plugins`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ cmsrel CMSSW_15_1_0_pre2
 cd CMSSW_15_1_0_pre2/src
 cmsenv
 git cms-init
+git cms-addpkg PhysicsTools/NanoAOD
 mkdir PhysicsTools
 cd PhysicsTools
 git clone git@github.com:kerstinlovisa/EXOnanoAOD.git
@@ -35,6 +36,11 @@ cmsRun Run3_2023_PAT_EXONANO_template.py
 # Event size of customized NanoAOD
 Check the event size of your custom EXOnanoAOD implementations in your nanoAOD root file (replace `nanoAOD.root`) by running:
 ```
-git cms-add
+git cms-addpkg PhysicsTools/NanoAOD
 $CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py nanoAOD.root --size size.html
 ```
+To check multiple datasets, edit use the script: 
+```
+sh test/run.sh
+```
+where output json files can be analyzed by `test/analyze.py`

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -5,11 +5,15 @@
 <use name="FWCore/PluginManager"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
+<use name="Geometry/RPCGeometry"/>
+<use name="Geometry/DTGeometry"/>
+<use name="Geometry/CSCGeometry"/>
 <use name="MagneticField/Records"/>
 <use name="PhysicsTools/RecoUtils"/>
 <use name="RecoVertex/KalmanVertexFit"/>
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/IPTools"/>
+<use name="fastjet"/>
 <flags EDM_PLUGIN="1"/>
 <export>
   <lib name="1"/>

--- a/plugins/cscMDSshowerTableProducer.cc
+++ b/plugins/cscMDSshowerTableProducer.cc
@@ -1,0 +1,396 @@
+#include <memory>
+#include <set>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/Math/interface/PtEtaPhiMass.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/PseudoJet.hh"
+  
+using RecHitRef = edm::Ref<CSCRecHit2DCollection>;
+using RecHitRefVector = edm::RefVector<CSCRecHit2DCollection>;
+
+class cscMDSshowerTableProducer : public edm::global::EDProducer<> {
+
+
+  public:
+    cscMDSshowerTableProducer(const edm::ParameterSet &iConfig)
+      :
+      geometryToken_(esConsumes<CSCGeometry, MuonGeometryRecord>()),
+      dtgeometryToken_(esConsumes<DTGeometry, MuonGeometryRecord>()),
+      rpcgeometryToken_(esConsumes<RPCGeometry, MuonGeometryRecord>()),
+      inputToken_(consumes<CSCRecHit2DCollection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
+      dtSegmentToken_(consumes<DTRecSegment4DCollection>(iConfig.getParameter<edm::InputTag>("segmentLabel"))),
+      rpchitToken_(consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("rpcLabel"))),
+      rParam_(iConfig.getParameter<double>("rParam")),
+      nRechitMin_(iConfig.getParameter<int>("nRechitMin")),
+      nStationThres_(iConfig.getParameter<int>("nStationThres")),
+      stripErr_(iConfig.getParameter<double>("stripErr")),
+      wireError_(iConfig.getParameter<double>("wireError")),
+      pruneCut_(iConfig.getParameter<double>("pruneCut")),
+      name_(iConfig.getParameter<std::string>("name"))
+      {
+      produces<nanoaod::FlatTable>(name_+"Rechits");
+      produces<nanoaod::FlatTable>(name_);
+    }
+
+    ~cscMDSshowerTableProducer() override {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("recHitLabel")->setComment("input cscRechit collection");
+      desc.add<edm::InputTag>("segmentLabel")->setComment("input dt segment collection for veto");
+      desc.add<edm::InputTag>("rpcLabel")->setComment("input rpcRechit collection for veto");
+      desc.add<double>("rParam", 0.4);
+      desc.add<int>("nRechitMin", 50);
+      desc.add<int>("nStationThres", 10);
+      desc.add<double>("stripErr", 7.0);
+      desc.add<double>("wireError", 8.6);
+      desc.add<double>("pruneCut", 9.0);
+      desc.add<std::string>("name","cscRechits")->setComment("name of the output collection");
+      descriptions.add("cscMDSshowerTable", desc);
+    }
+    float getWeightedTime(RecHitRefVector rechits) const;
+
+  private:
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geometryToken_;
+    const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtgeometryToken_;
+    const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcgeometryToken_;
+    edm::EDGetTokenT<CSCRecHit2DCollection> inputToken_;
+    edm::EDGetTokenT<DTRecSegment4DCollection> dtSegmentToken_;
+    edm::EDGetTokenT<RPCRecHitCollection> rpchitToken_;
+    const double rParam_;
+    const int nRechitMin_;     // min number of rechits
+    const int nStationThres_;  // min number of rechits to count towards nStation 
+    const double stripErr_,wireError_,pruneCut_; //constants for CSC time
+    const std::string name_;
+};
+
+//From: https://github.com/cms-sw/cmssw/blob/master/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc#L165-L234
+float cscMDSshowerTableProducer::getWeightedTime(RecHitRefVector rechits) const{
+     
+      bool modified = false;
+      double totalWeightTimeVtx = 0;
+      float timeVtx = 0;
+
+      do {
+      modified = false;
+      totalWeightTimeVtx = 0;
+      timeVtx = 0;
+      for (auto const& rechit : rechits) {
+        timeVtx += rechit->wireTime() * 1./(wireError_*wireError_);
+        timeVtx += rechit->tpeak() * 1./(stripErr_*stripErr_);
+        totalWeightTimeVtx += 1./(wireError_*wireError_);
+        totalWeightTimeVtx += 1./(stripErr_*stripErr_);
+      }
+      timeVtx /= totalWeightTimeVtx;
+
+      // cut away outliers
+      double diff_tvtx_strip,diff_tvtx_wire;
+      double chimax = 0.0;
+      int tmmax=0;
+      for (size_t i = 0; i < rechits.size(); ++i) {
+        const auto& rechit = rechits[i];
+        //diff_tvtx = (cscHits[i].time - timeVtx) * (cscHits[i].time - timeVtx) * cscHits[i].error;
+        diff_tvtx_strip = (rechit->tpeak() - timeVtx) * (rechit->tpeak() - timeVtx) *  1./(stripErr_*stripErr_);
+        diff_tvtx_wire = (rechit->wireTime() - timeVtx) * (rechit->wireTime() - timeVtx) *  1./(wireError_*wireError_);
+    
+        if ((diff_tvtx_strip > chimax)||(diff_tvtx_wire>chimax)) {
+          tmmax =  i;
+          chimax = std::max(diff_tvtx_strip,diff_tvtx_wire);
+        }
+      }
+      // cut away the outliers and repeat 
+      if (chimax > pruneCut_) {
+        rechits.erase(rechits.begin()+tmmax);
+        modified = true;
+      }
+    } while (modified);
+
+    return timeVtx;
+}
+
+
+void cscMDSshowerTableProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+ 
+  auto const& geo = iSetup.getData(geometryToken_);
+  auto const& dt_geo = iSetup.getData(dtgeometryToken_);
+  auto const& rpc_geo = iSetup.getData(rpcgeometryToken_);
+  auto const& rechits = iEvent.get(inputToken_);
+  auto const& segments = iEvent.get(dtSegmentToken_);
+  auto const& rpchits = iEvent.get(rpchitToken_);
+
+  std::set<CSCDetId> unique_ids;
+  std::vector<fastjet::PseudoJet> fjInput;
+
+  edm::RefVector<CSCRecHit2DCollection> inputs;
+
+  fastjet::JetDefinition jet_def(fastjet::cambridge_algorithm, rParam_);
+
+  int recIt = 0;
+  for (auto const& rechit : rechits) {
+    LocalPoint recHitLocalPosition = rechit.localPosition();
+    auto detid = rechit.cscDetId();
+    auto thischamber = geo.chamber(detid);
+    if (thischamber) {
+      GlobalPoint globalPosition = thischamber->toGlobal(recHitLocalPosition);
+      float x = globalPosition.x();
+      float y = globalPosition.y();
+      float z = globalPosition.z();
+      RecHitRef ref = RecHitRef(&rechits, recIt);
+      inputs.push_back(ref);
+      fjInput.push_back(fastjet::PseudoJet(x, y, z, globalPosition.mag()));
+      fjInput.back().set_user_index(recIt);
+    }
+    recIt++;
+  }
+  fastjet::ClusterSequence clus_seq(fjInput, jet_def);
+
+  //keep all the clusters
+  double ptmin = 0.0;
+  std::vector<fastjet::PseudoJet> fjJets = clus_seq.inclusive_jets(ptmin);
+
+  // Constituent rechit fields
+  std::vector<float> cscRechitsX,cscRechitsY,cscRechitsZ,cscRechitsPhi,cscRechitsEta,cscRechitsE,cscRechitsTpeak,cscRechitsTwire;
+  std::vector<int> cscRechitsNStrips,cscRechitsHitWire,cscRechitsWGroupsBX,cscRechitsNWireGroups,cscRechitsQuality,cscRechitsChamber,cscRechitsIChamber,cscRechitsStation;;
+
+  // MDS fields
+  std::vector<float> clsX,clsY,clsZ,clsPhi,clsEta,clsTime,clsTimeSpread,clsTimeWeighted,clsTimeSpreadWeighted,clsAvgStation;
+  std::vector<int> clsSize,clsNstation,cls_nME11,cls_nME12,clsUniqueChamber,cls_nMB1dtSeg,cls_nRE12hit,cls_nRB1hit;
+
+  for (auto const& fjJet : fjJets) {
+    // skip if the cluster has too few rechits
+    if (int(fjJet.constituents().size()) < nRechitMin_)
+      continue;
+    // get the constituents from fastjet
+    RecHitRefVector rechits;
+    for (auto const& constituent : fjJet.constituents()) {
+      auto index = constituent.user_index();
+      if (index >= 0 && static_cast<unsigned int>(index) < inputs.size()) {
+        rechits.push_back(inputs[index]);
+      }
+    }
+
+    //Derive cluster properties
+    int nME12=0,nME11=0,nMB1dtSeg = 0,nRE12hit=0,nRB1hit=0;
+    int nStation = 0;
+    int totStation = 0;
+    float avgStation = 0.0;
+    float timeSpread = 0.0;
+    float time = 0.0;
+    float time_strip = 0.0;  // for timeSpread calculation
+    double timeWeighted = 0.0;
+    float timeSpreadWeighted = 0.0;   
+
+    std::map<int, int> station_count_map;
+
+    //fill rechits fields
+    for (auto const& rechit : rechits) {
+    
+      LocalPoint recHitLocalPosition = rechit->localPosition();
+      auto detid = rechit->cscDetId();
+      unique_ids.insert(detid.chamberId());
+      auto thischamber = geo.chamber(detid);
+      int endcap = CSCDetId::endcap(detid) == 1 ? 1 : -1;
+      if (thischamber) {
+        GlobalPoint globalPosition = thischamber->toGlobal(recHitLocalPosition);
+    
+        cscRechitsX.push_back( globalPosition.x());
+        cscRechitsY.push_back( globalPosition.y());
+        cscRechitsZ.push_back( globalPosition.z());
+        cscRechitsPhi.push_back( globalPosition.phi());
+        cscRechitsEta.push_back( globalPosition.eta());
+        cscRechitsE.push_back( rechit->energyDepositedInLayer());//not saved
+        cscRechitsTpeak.push_back( rechit->tpeak());
+        cscRechitsTwire.push_back( rechit->wireTime());
+        cscRechitsQuality.push_back( rechit->quality());
+
+        int stationRing = (CSCDetId::station(detid) * 10 + CSCDetId::ring(detid));
+        if (CSCDetId::ring(detid) == 4)
+          stationRing = (CSCDetId::station(detid) * 10 + 1);  // ME1/a has ring==4
+
+        cscRechitsChamber.push_back( endcap * stationRing);
+        cscRechitsIChamber.push_back( CSCDetId::chamber(detid));
+        cscRechitsStation.push_back( endcap *CSCDetId::station(detid));
+        cscRechitsNStrips.push_back(  rechit->nStrips());
+        cscRechitsHitWire.push_back(  rechit->hitWire());
+        cscRechitsWGroupsBX.push_back(  rechit->wgroupsBX());
+        cscRechitsNWireGroups.push_back(  rechit->nWireGroups());
+
+        //compute for cluster fields
+        station_count_map[CSCDetId::station(detid)]++;    
+        if (stationRing == 11)
+          nME11++;
+        if (stationRing == 12)
+          nME12++;
+        time += (rechit->tpeak() + rechit->wireTime());
+        time_strip += rechit->tpeak();
+      }
+    }
+    //station statistics
+    std::map<int, int>::iterator it;
+    for (auto const& [station, count] : station_count_map) {
+      if (count >= nStationThres_) {
+        nStation++;
+        avgStation += station * count;
+        totStation += count;
+      }
+    }
+    if (totStation != 0) {
+      avgStation = avgStation / totStation;
+    }
+    float invN = 1.f / rechits.size();
+    time = (time / 2.f) * invN;
+    time_strip = time_strip * invN;
+
+    // https://github.com/cms-sw/cmssw/blob/master/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc#L165-L234
+    for (auto& rechit : rechits) {
+      timeSpread += (rechit->tpeak() - time_strip) * (rechit->tpeak() - time_strip);
+    }
+    timeSpread = std::sqrt(timeSpread * invN);
+
+    float i_clsEta = etaFromXYZ(fjJet.px() * invN, fjJet.py() * invN,fjJet.pz() * invN);
+    float i_clsPhi = std::atan2(fjJet.py() * invN, fjJet.px() * invN);
+
+    //MB1 DT seg 
+    for (auto const& segment : segments) {
+    
+        LocalPoint localPosition = segment.localPosition();
+        auto geoid = segment.geographicalId();
+        DTChamberId dtdetid = DTChamberId(geoid);
+        auto thischamber = dt_geo.chamber(dtdetid);
+        if (thischamber) {
+          GlobalPoint globalPosition = thischamber->toGlobal(localPosition);
+          float eta = globalPosition.eta();
+          float phi = globalPosition.phi();
+          if (dtdetid.station()==1 && reco::deltaR(eta,phi,i_clsEta,i_clsPhi)<0.4) nMB1dtSeg++;
+        }
+    }
+    //RPC hits
+    for (auto const& rechit : rpchits) {
+
+        LocalPoint recHitLocalPosition = rechit.localPosition();
+        auto geoid = rechit.geographicalId();
+        RPCDetId rpcdetid = RPCDetId(geoid);
+        auto thischamber = rpc_geo.chamber(rpcdetid);
+    
+        if (thischamber) {
+          GlobalPoint globalPosition = thischamber->toGlobal(recHitLocalPosition);
+          float eta = globalPosition.eta();
+          float phi = globalPosition.phi();
+         
+          //RE12 hits 
+          if (rpcdetid.station()==1 && rpcdetid.ring()==2 && abs(rpcdetid.region())==1 && reco::deltaR(eta,phi,i_clsEta,i_clsPhi)<0.4) nRE12hit++;
+          //RB1 hits 
+          if (rpcdetid.station()==1 && rpcdetid.region()==0 && reco::deltaR(eta,phi,i_clsEta,i_clsPhi)<0.4) nRB1hit++;
+        }
+    }
+
+    //fill cluster fields
+    clsSize.push_back(rechits.size());
+    // cluster position is the average position of the constituent rechits
+    clsX.push_back(fjJet.px() * invN);
+    clsY.push_back(fjJet.py() * invN);
+    clsZ.push_back(fjJet.pz() * invN);
+    clsEta.push_back(i_clsEta);
+    clsPhi.push_back(i_clsPhi);
+
+    clsTime.push_back(time);
+    clsTimeSpread.push_back(timeSpread);
+    cls_nME11.push_back(nME11);
+    cls_nME12.push_back(nME12);
+    clsNstation.push_back(nStation);
+    clsAvgStation.push_back(avgStation);
+    clsUniqueChamber.push_back(unique_ids.size());
+    cls_nMB1dtSeg.push_back(nMB1dtSeg);
+    cls_nRE12hit.push_back(nRE12hit);
+    cls_nRB1hit.push_back(nRB1hit);
+
+    //cluster time weighted with unc. and pruned outliers
+    timeWeighted = cscMDSshowerTableProducer::getWeightedTime(rechits);
+
+    for (auto& rechit : rechits) {
+      timeSpreadWeighted += (timeWeighted - rechit->tpeak()) * (timeWeighted - rechit->tpeak());
+    }
+    timeSpreadWeighted = std::sqrt(timeSpreadWeighted * invN);
+
+    clsTimeWeighted.push_back(timeWeighted);
+    clsTimeSpreadWeighted.push_back(timeSpreadWeighted);
+
+  }
+  auto cscRechitTab = std::make_unique<nanoaod::FlatTable>(cscRechitsX.size(), name_+"Rechits", false, false);
+
+  cscRechitTab->addColumn<float>("X", cscRechitsX, "csc rechit X");
+  cscRechitTab->addColumn<float>("Y", cscRechitsY, "csc rechit Y");
+  cscRechitTab->addColumn<float>("Z", cscRechitsZ, "csc rechit Z");
+  cscRechitTab->addColumn<float>("Phi", cscRechitsPhi, "csc rechit Phi");
+  cscRechitTab->addColumn<float>("Eta", cscRechitsEta, "csc rechit Eta");
+  cscRechitTab->addColumn<float>("E", cscRechitsE, "csc rechit Energy deposited in layer");
+  cscRechitTab->addColumn<float>("Tpeak", cscRechitsTpeak, "csc rechit time from cathode");
+  cscRechitTab->addColumn<float>("Twire", cscRechitsTwire, "csc rechit time from anode");
+  cscRechitTab->addColumn<int>("Quality", cscRechitsQuality, "csc rechit quality");
+  cscRechitTab->addColumn<int>("Chamber", cscRechitsChamber, "csc rechit station-Ring");
+  cscRechitTab->addColumn<int>("IChamber", cscRechitsIChamber, "csc rechit chamber in ring" );
+  cscRechitTab->addColumn<int>("Station", cscRechitsStation, "csc rechit station");
+  cscRechitTab->addColumn<int>("NStrips", cscRechitsNStrips, "csc rechit nstrips");
+  cscRechitTab->addColumn<int>("WGroupsBX", cscRechitsWGroupsBX, "csc rechit wire group BX");
+  cscRechitTab->addColumn<int>("HitWire",    cscRechitsHitWire, "csc rechit hit wire");
+  cscRechitTab->addColumn<int>("NWireGroups", cscRechitsNWireGroups, "csc rechit n wire groups");
+
+
+  iEvent.put(std::move(cscRechitTab), name_+"Rechits"); 
+
+  auto clsTab = std::make_unique<nanoaod::FlatTable>(clsSize.size(), name_, false, false);
+
+  clsTab->addColumn<int>("size", clsSize, "cluster Size");
+  clsTab->addColumn<float>("x", clsX, "cluster X");
+  clsTab->addColumn<float>("y", clsY, "cluster Y");
+  clsTab->addColumn<float>("z", clsZ, "cluster Z");
+  clsTab->addColumn<float>("phi", clsPhi, "cluster Phi");
+  clsTab->addColumn<float>("eta", clsEta, "cluster Eta");
+  clsTab->addColumn<float>("time", clsTime, "cluster Time");
+  clsTab->addColumn<float>("timeSpread", clsTimeSpread, "cluster TimeSpread");
+  clsTab->addColumn<float>("timeWeighted", clsTimeWeighted, "cluster TimeWeighted");
+  clsTab->addColumn<float>("timeSpreadWeighted", clsTimeSpreadWeighted, "cluster TimeSpreadWeighted");
+  clsTab->addColumn<int>("nStation", clsNstation, "cluster nStation");
+  clsTab->addColumn<int>("uniqueChamber", clsUniqueChamber, "cluster unique chambers");
+  clsTab->addColumn<float>("avgStation", clsAvgStation, "cluster AvgStation");
+  clsTab->addColumn<int>("nME11", cls_nME11, "cluster nME11");
+  clsTab->addColumn<int>("nME12", cls_nME12, "cluster nME12");
+  clsTab->addColumn<int>("nMB1dtSeg", cls_nMB1dtSeg, "cluster nMB1dtSeg");
+  clsTab->addColumn<int>("nRE12hit", cls_nRE12hit, "cluster nRE12hit");
+  clsTab->addColumn<int>("nRB1hit", cls_nRB1hit, "cluster nRB1hit");
+
+  iEvent.put(std::move(clsTab), name_); 
+
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(cscMDSshowerTableProducer);
+

--- a/plugins/dtMDSshowerTableProducer.cc
+++ b/plugins/dtMDSshowerTableProducer.cc
@@ -1,0 +1,355 @@
+#include <memory>
+#include <set>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/Math/interface/PtEtaPhiMass.h"
+#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/PseudoJet.hh"
+  
+using RecHitRef = edm::Ref<DTRecHitCollection>;
+using RecHitRefVector = edm::RefVector<DTRecHitCollection>;
+
+class dtMDSshowerTableProducer : public edm::global::EDProducer<> {
+
+
+  public:
+    dtMDSshowerTableProducer(const edm::ParameterSet &iConfig)
+      :
+      dtgeometryToken_(esConsumes<DTGeometry, MuonGeometryRecord>()),
+      rpcgeometryToken_(esConsumes<RPCGeometry, MuonGeometryRecord>()),
+      inputToken_(consumes<DTRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
+      rpchitToken_(consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("rpcLabel"))),
+      rParam_(iConfig.getParameter<double>("rParam")),
+      nRechitMin_(iConfig.getParameter<int>("nRechitMin")),
+      nStationThres_(iConfig.getParameter<int>("nStationThres")),
+      name_(iConfig.getParameter<std::string>("name"))
+      {
+      produces<nanoaod::FlatTable>(name_+"Rechits");
+      produces<nanoaod::FlatTable>(name_);
+    }
+
+    ~dtMDSshowerTableProducer() override {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("recHitLabel")->setComment("input dtRechit collection");
+      desc.add<edm::InputTag>("rpcLabel")->setComment("input rpcRechit collection for veto");
+      desc.add<double>("rParam", 0.4);
+      desc.add<int>("nRechitMin", 50);
+      desc.add<int>("nStationThres", 10);
+      desc.add<std::string>("name","dt1DRecHits")->setComment("name of the output collection");
+      descriptions.add("dtMDSshowerTable", desc);
+    }
+    float getWeightedTime(RecHitRefVector rechits) const;
+
+  private:
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtgeometryToken_;
+    const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcgeometryToken_;
+    edm::EDGetTokenT<DTRecHitCollection> inputToken_;
+    edm::EDGetTokenT<RPCRecHitCollection> rpchitToken_;
+    const double rParam_;
+    const int nRechitMin_;     // min number of rechits
+    const int nStationThres_;  // min number of rechits to count towards nStation 
+    const std::string name_;
+};
+
+
+void dtMDSshowerTableProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+ 
+  auto const& dt_geo = iSetup.getData(dtgeometryToken_);
+  auto const& rpc_geo = iSetup.getData(rpcgeometryToken_);
+  auto const& rechits = iEvent.get(inputToken_);
+  auto const& rpchits = iEvent.get(rpchitToken_);
+
+  std::set<DTChamberId> unique_ids;
+  std::vector<fastjet::PseudoJet> fjInput;
+
+  RecHitRefVector inputs;
+
+  fastjet::JetDefinition jet_def(fastjet::cambridge_algorithm, rParam_);
+
+  int recIt = 0;
+  for (auto const& rechit : rechits) {
+    LocalPoint recHitLocalPosition = rechit.localPosition();
+    auto geoid = rechit.geographicalId();
+    DTChamberId dtdetid = DTChamberId(geoid);
+    DTLayerId  dtlayerid = DTLayerId(geoid);
+
+    auto thischamber = dt_geo.chamber(dtdetid);
+    auto thislayer   = dt_geo.layer(dtlayerid);
+
+    if (thischamber) {
+      GlobalPoint globalPosition;
+      if (thislayer){
+        globalPosition = thislayer->toGlobal(recHitLocalPosition);
+      }
+      else{
+        globalPosition = thischamber->toGlobal(recHitLocalPosition);
+      }
+      float x = globalPosition.x();
+      float y = globalPosition.y();
+      float z = globalPosition.z();
+      RecHitRef ref = RecHitRef(&rechits, recIt);
+      inputs.push_back(ref);
+      fjInput.push_back(fastjet::PseudoJet(x, y, z, globalPosition.mag()));
+      fjInput.back().set_user_index(recIt);
+    }
+    recIt++;
+  }
+  fastjet::ClusterSequence clus_seq(fjInput, jet_def);
+
+  //keep all the clusters
+  double ptmin = 0.0;
+  std::vector<fastjet::PseudoJet> fjJets = clus_seq.inclusive_jets(ptmin);
+
+  // Constituent rechit fields
+  std::vector<float> dtRechitsX,dtRechitsY,dtRechitsZ,dtRechitsPhi,dtRechitsEta;
+  std::vector<int> dtRechitsLayer,dtRechitsSuperLayer,dtRechitsSector,dtRechitsStation,dtRechitsWheel;
+
+  // MDS fields
+  std::vector<float> clsX,clsY,clsZ,clsPhi,clsEta,clsAvgStation;
+  std::vector<int> clsSize,clsNstation,clsWheel,clsUniqueChamber,cls_nRB1hit,cls_nRPC,clsBX;
+
+  for (auto const& fjJet : fjJets) {
+    // skip if the cluster has too few rechits
+    if (int(fjJet.constituents().size()) < nRechitMin_)
+      continue;
+    // get the constituents from fastjet
+    RecHitRefVector rechits;
+    for (auto const& constituent : fjJet.constituents()) {
+      auto index = constituent.user_index();
+      if (index >= 0 && static_cast<unsigned int>(index) < inputs.size()) {
+        rechits.push_back(inputs[index]);
+      }
+    }
+
+    //Derive cluster properties
+    int size_z=0,size_xy=0,size=0;
+    float avg_x_sl2(0.0), avg_y_sl2(0.0), avg_z_sl2(0.0);
+    float avg_x(0.0), avg_y(0.0), avg_z(0.0);
+    int nStation = 0;
+    int totStation = 0;
+    float avgStation = 0.0;
+
+    std::map<int, int> station_count_map;
+
+    //fill rechits fields
+    for (auto const& rechit : rechits) {
+    
+        LocalPoint recHitLocalPosition = rechit->localPosition();
+        auto geoid = rechit->geographicalId();
+      
+        DTChamberId dtdetid = DTChamberId(geoid);
+        DTLayerId  dtlayerid = DTLayerId(geoid);
+
+        unique_ids.insert(dtdetid);
+    
+        auto thischamber = dt_geo.chamber(dtdetid);
+        auto thislayer   = dt_geo.layer(dtlayerid);
+    
+        if (thischamber) {
+    
+          if (thislayer){
+              GlobalPoint globalPosition = thislayer->toGlobal(recHitLocalPosition);
+              dtRechitsX.push_back( globalPosition.x());
+              dtRechitsY.push_back( globalPosition.y());
+              dtRechitsZ.push_back( globalPosition.z());
+              dtRechitsPhi.push_back( globalPosition.phi());
+              dtRechitsEta.push_back( globalPosition.eta());
+              dtRechitsLayer.push_back( dtlayerid.layer());
+              dtRechitsSuperLayer.push_back( dtlayerid.superlayer());
+              // use xy-coordinates from SL1/SL3 when available 
+              if (dtlayerid.superlayer()==1 || dtlayerid.superlayer()==3){
+                   avg_x += globalPosition.x();
+                   avg_y += globalPosition.y();
+                   avg_z += globalPosition.z();
+                   size_xy++;
+              } 
+              // use z-coordinates from SL2 when available 
+              else if (dtlayerid.superlayer()==2){
+                   avg_x_sl2 += globalPosition.x();
+                   avg_y_sl2 += globalPosition.y();
+                   avg_z_sl2 += globalPosition.z();
+                   size_z++;
+              }
+          }
+          else{
+              GlobalPoint globalPosition = thischamber->toGlobal(recHitLocalPosition);
+              dtRechitsX.push_back( globalPosition.x());
+              dtRechitsY.push_back( globalPosition.y());
+              dtRechitsZ.push_back( globalPosition.z());
+              dtRechitsPhi.push_back( globalPosition.phi());
+              dtRechitsEta.push_back( globalPosition.eta());
+              dtRechitsLayer.push_back( 0 );     //default value;
+              dtRechitsSuperLayer.push_back( 0 );//default value
+              avg_x += globalPosition.x();
+              avg_y += globalPosition.y();
+              avg_z += globalPosition.z();
+          }
+          dtRechitsSector.push_back( dtdetid.sector());
+          dtRechitsStation.push_back( dtdetid.station());
+          dtRechitsWheel.push_back( dtdetid.wheel());
+          size++; 
+        
+          //compute for cluster fields
+          station_count_map[dtdetid.station()]++;    
+        }
+    }
+    //station statistics
+    std::map<int, int>::iterator it;
+    for (auto const& [station, count] : station_count_map) {
+      if (count >= nStationThres_) {
+        nStation++;
+        avgStation += station * count;
+        totStation += count;
+      }
+    }
+    if (totStation != 0) {
+      avgStation = avgStation / totStation;
+    }
+
+    //for DT correct position, calculate average Z using sl2 and average XY using sl1/3
+    if (size_xy > 0 && size_z > 0) {   // both SL1/SL3 and SL2 rechits
+      avg_x = avg_x/size_xy;
+      avg_y = avg_y/size_xy;
+      avg_z = avg_z_sl2/size_z;
+    }
+    else if (size_xy == 0 && size_z > 0)// only SL2 rechits
+    {
+      avg_x = avg_x_sl2/size_z;
+      avg_y = avg_y_sl2/size_z;
+      avg_z = avg_z_sl2/size_z;
+    }
+    else if (size_xy > 0 && size_z == 0) // no SL2 rechits
+    {
+      avg_x = avg_x/size_xy;
+      avg_y = avg_y/size_xy;
+      avg_z = avg_z/size_xy;
+    }
+    else                                // no SL information
+    {
+      avg_x = avg_x/size;
+      avg_y = avg_y/size;
+      avg_z = avg_z/size;
+    }
+
+
+    float i_clsEta = etaFromXYZ(avg_x, avg_y,avg_z);
+    float i_clsPhi = std::atan2(avg_y, avg_x);
+    int i_clsWheel = (std::abs(avg_z) < 126.8) ? 0 :
+        (avg_z > 126.8 && avg_z < 395.4) ? 1 :
+        (avg_z < -126.8 && avg_z > -395.4) ? -1 :
+        (avg_z < 0) ? -2 : 2;
+
+    // RPC hits
+    std::map<int, int> bxCounts; // bx of matched RPC hits : counts
+    int nRB1hit=0;
+    for (auto const& rechit : rpchits) {
+
+        LocalPoint recHitLocalPosition = rechit.localPosition();
+        auto geoid = rechit.geographicalId();
+        RPCDetId rpcdetid = RPCDetId(geoid);
+        auto thischamber = rpc_geo.chamber(rpcdetid);
+   
+        // Only matching RB hits 
+        if (rpcdetid.region()!=0) continue;
+        if (thischamber) {
+          GlobalPoint globalPosition = thischamber->toGlobal(recHitLocalPosition);
+ 
+          //match to RPC hits with dPhi<0.5 and same wheel in DT
+          if (reco::deltaPhi(globalPosition.phi(),i_clsPhi)<0.5 && rpcdetid.ring()==i_clsWheel) {
+            //RB1 hits 
+            if (rpcdetid.station()==1) nRB1hit++;
+            bxCounts[rechit.BunchX()]++;
+          }
+        }
+    }
+    // find the mode of BX
+    int modeBX = 0,maxCount = 0, i_cls_nRPC = 0;
+    for (const auto& [bx, count] : bxCounts) {
+      i_cls_nRPC += count;
+      if (count > maxCount) {
+        modeBX = bx;
+        maxCount = count;
+      }
+    }
+
+    //fill cluster fields
+    clsSize.push_back(rechits.size());
+    // cluster position is the average position of the constituent rechits
+    clsX.push_back(avg_x);
+    clsY.push_back(avg_y);
+    clsZ.push_back(avg_z);
+    clsEta.push_back(i_clsEta);
+    clsPhi.push_back(i_clsPhi);
+    clsBX.push_back(modeBX);
+    clsNstation.push_back(nStation);
+    clsAvgStation.push_back(avgStation);
+    clsWheel.push_back(i_clsWheel);
+    clsUniqueChamber.push_back(unique_ids.size());
+    cls_nRB1hit.push_back(nRB1hit);
+    cls_nRPC.push_back(i_cls_nRPC);
+
+  }
+  auto dtRechitTab = std::make_unique<nanoaod::FlatTable>(dtRechitsX.size(), name_+"Rechits", false, false);
+
+  dtRechitTab->addColumn<float>("X", dtRechitsX, "dt rechit X");
+  dtRechitTab->addColumn<float>("Y", dtRechitsY, "dt rechit Y");
+  dtRechitTab->addColumn<float>("Z", dtRechitsZ, "dt rechit Z");
+  dtRechitTab->addColumn<float>("Phi", dtRechitsPhi, "dt rechit Phi");
+  dtRechitTab->addColumn<float>("Eta", dtRechitsEta, "dt rechit Eta");
+  dtRechitTab->addColumn<int>("Layer", dtRechitsLayer, "dt rechit Layer");
+  dtRechitTab->addColumn<int>("SuperLayer", dtRechitsSuperLayer, "dt rechit SuperLayer");
+  dtRechitTab->addColumn<int>("Sector", dtRechitsSector, "dt rechit sector");
+  dtRechitTab->addColumn<int>("Station", dtRechitsStation, "dt rechit station");
+  dtRechitTab->addColumn<int>("Wheel", dtRechitsWheel, "dt rechit nstrips");
+
+  iEvent.put(std::move(dtRechitTab), name_+"Rechits"); 
+
+  auto clsTab = std::make_unique<nanoaod::FlatTable>(clsSize.size(), name_, false, false);
+
+  clsTab->addColumn<int>("size", clsSize, "cluster Size");
+  clsTab->addColumn<float>("x", clsX, "cluster X");
+  clsTab->addColumn<float>("y", clsY, "cluster Y");
+  clsTab->addColumn<float>("z", clsZ, "cluster Z");
+  clsTab->addColumn<float>("phi", clsPhi, "cluster Phi");
+  clsTab->addColumn<float>("eta", clsEta, "cluster Eta");
+  clsTab->addColumn<int>("bx", clsBX, "cluster BX");
+  clsTab->addColumn<int>("wheel", clsWheel, "cluster wheel");
+  clsTab->addColumn<int>("nStation", clsNstation, "cluster nStation");
+  clsTab->addColumn<int>("uniqueChamber", clsUniqueChamber, "cluster unique chambers");
+  clsTab->addColumn<float>("avgStation", clsAvgStation, "cluster AvgStation");
+  clsTab->addColumn<int>("nRPC", cls_nRPC, "cluster nRPC");
+  clsTab->addColumn<int>("nRB1hit", cls_nRB1hit, "cluster nRB1hit");
+
+  iEvent.put(std::move(clsTab), name_); 
+
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(dtMDSshowerTableProducer);
+

--- a/python/custom_exo_cff.py
+++ b/python/custom_exo_cff.py
@@ -1,38 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 
-from RecoMuon.MuonRechitClusterProducer.cscRechitClusterProducer_cfi import cscRechitClusterProducer
-from RecoMuon.MuonRechitClusterProducer.dtRechitClusterProducer_cfi import dtRechitClusterProducer 
+from HMTntuple.CSCShowerAnalyzer.cscMDSshowerTable_cfi import cscMDSshowerTable 
+from HMTntuple.CSCShowerAnalyzer.dtMDSshowerTable_cfi import dtMDSshowerTable 
 
-# MDSnano tables 
-cscMDSClusterTable = cms.EDProducer("SimpleMuonRecHitClusterFlatTableProducer",
-    src  = cms.InputTag("ca4CSCrechitClusters"),
-    name = cms.string("cscMDSHLTCluster"),
-    doc  = cms.string("MDS cluster at HLT"),
-    variables = cms.PSet(
-        eta = Var("eta", float, doc="cluster eta"),
-        phi = Var("phi", float, doc="cluster phi"),
-        x   = Var("x"  , float, doc="cluster x"),
-        y   = Var("y"  , float, doc="cluster y"),
-        z   = Var("z"  , float, doc="cluster z"),
-        r   = Var("r"  , float, doc="cluster r"),
-        size   = Var("size"  , int, doc="cluster size"),
-        nStation   = Var("nStation"  , int, doc="cluster nStation"),
-        avgStation   = Var("avgStation"  , float, doc="cluster avgStation"),
-        nMB1   = Var("nMB1"  , int, doc="cluster nMB1"),
-        nMB2   = Var("nMB2"  , int, doc="cluster nMB2"),
-        nME11   = Var("nME11"  , int, doc="cluster nME11"),
-        nME12   = Var("nME12"  , int, doc="cluster nME12"),
-        nME41   = Var("nME41"  , int, doc="cluster nME41"),
-        nME42   = Var("nME42"  , int, doc="cluster nME42"),
-        time   = Var("time"  , float, doc="cluster time = avg cathode and anode time"),
-        timeSpread   = Var("timeSpread"  , float, doc="cluster timeSpread")
-    )
+cscMDSshowerTable = cscMDSshowerTable.clone( 
+    name = cms.string("cscMDSCluster"),
+    recHitLabel = cms.InputTag("csc2DRecHits"),
+    segmentLabel = cms.InputTag("dt4DSegments"),
+    rpcLabel = cms.InputTag("rpcRecHits")
 )
-
-dtMDSClusterTable = cscMDSClusterTable.clone(
-    src = cms.InputTag("ca4DTrechitClusters"),
-    name= cms.string("dtMDSHLTCluster")
+dtMDSshowerTable = dtMDSshowerTable.clone( 
+    name = cms.string("dtMDSCluster"),
+    recHitLabel = cms.InputTag("dt1DRecHits"),
+    rpcLabel = cms.InputTag("rpcRecHits")
 )
 
 #DSA muon tables
@@ -67,21 +48,36 @@ electronVertexTable = cms.EDProducer("ElectronVertexTableProducer",
     primaryVertex=cms.InputTag("offlineSlimmedPrimaryVertices")
 )
 
-electronExtendedTable = cms.EDProducer("ElectronExtendedTableProducer",
-    name=cms.string("Electron"),
+dispJetTable = cms.EDProducer("DispJetTableProducer",
+    rho=cms.InputTag("fixedGridRhoFastjetAll"),
     electrons=cms.InputTag("linkedObjects","electrons"),
+    muons=cms.InputTag("linkedObjects","muons"),
+    jets=cms.InputTag("linkedObjects","jets"),
+    jetsFat=cms.InputTag("slimmedJetsAK8"),
+    jetsSub=cms.InputTag("slimmedJetsAK8PFPuppiSoftDropPacked", "SubJets"),
+    primaryVertex = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    secondaryVertex = cms.InputTag("displacedInclusiveSecondaryVertices")
 )
 
-def add_mdsTables(process):
-    process.ca4CSCrechitClusters = cscRechitClusterProducer    
-    process.ca4DTrechitClusters = dtRechitClusterProducer
-    process.cscMDSClusterTable = cscMDSClusterTable
-    process.dtMDSClusterTable = dtMDSClusterTable 
+def add_dispJetTables(process):
+    process.load('PhysicsTools.EXOnanoAOD.displacedInclusiveVertexing_cff')
+    process.dispJetTable = dispJetTable
+    process.dispJetTask = cms.Task(process.unpackedTracksAndVertices)
+    process.dispJetTask.add(process.displacedInclusiveVertexFinder)
+    process.dispJetTask.add(process.displacedVertexMerger)
+    process.dispJetTask.add(process.displacedTrackVertexArbitrator)
+    process.dispJetTask.add(process.displacedInclusiveSecondaryVertices)
+    process.dispJetTask.add(process.dispJetTable)
+    process.nanoTableTaskCommon.add(process.dispJetTask)
 
-    process.MDSTask = cms.Task(process.ca4CSCrechitClusters)
-    process.MDSTask.add(process.ca4DTrechitClusters)
-    process.MDSTask.add(process.cscMDSClusterTable)
-    process.MDSTask.add(process.dtMDSClusterTable)
+    return process
+
+def add_mdsTables(process):
+    process.cscMDSshowerTable = cscMDSshowerTable    
+    process.dtMDSshowerTable = dtMDSshowerTable   
+
+    process.MDSTask = cms.Task(process.cscMDSshowerTable)
+    process.MDSTask.add(process.dtMDSshowerTable)
 
     process.nanoTableTaskCommon.add(process.MDSTask)
 
@@ -111,13 +107,8 @@ def add_electronVertexTables(process):
     process.load('TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi')
 
     process.electronVertexTable = electronVertexTable
-    process.electronExtendedTable = electronExtendedTable
-
     process.electronVertexTask = cms.Task(process.electronVertexTable)
-    process.electronExtendedTask = cms.Task(process.electronExtendedTable)
-
     process.nanoTableTaskCommon.add(process.electronVertexTask)
-    process.nanoTableTaskCommon.add(process.electronExtendedTask)
 
     return process
 
@@ -135,9 +126,10 @@ def update_genParticleTable(process):
 
 def add_exonanoTables(process):
 
-    process = add_mdsTables(process)
+    process = add_mdsTables(process) ## Commented out right now because it needs changes in PhysicsTools/NanoAOD
     process = add_dsamuonTables(process)
     process = add_electronVertexTables(process)
+    process = add_dispJetTables(process)
     process = update_genParticleTable(process)
 
     return process

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -148,11 +148,8 @@ if __name__ == "__main__":
                    ("size_EGamma_v1.json", "size_EGamma_ref.json"),
                    #("size_Muon.json","size_Muon_ref.json"),
                    ("size_Muon_v1.json","size_Muon_ref.json"),
-                   #("size_MDSskim.json","size_MDSskim_ref.json"),
-                   ("size_MDSskim_v1.json","size_MDSskim_ref.json"),
                    #("size_TT.json","size_TT_ref.json"),
                    ("size_TT_v1.json","size_TT_ref.json")
-                   #("size_signal.json","size_TT_ref.json")
                    ]
     for size_file, ref_file in json_files:
         parsed_data = parse_json(size_file, ref_file)

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -1,0 +1,161 @@
+import json
+import os
+from tabulate import tabulate
+
+def parse_json(file_path, file_ref):
+    """Parse a JSON file and extract specified fields."""
+    with open(file_path, 'r', encoding='utf-8') as file:
+        data = json.load(file)
+    with open(file_ref, 'r', encoding='utf-8') as file:
+        data_ref = json.load(file)
+    groups = data['trees']["Events"]["branchgroups"]
+    groups_ref = data_ref['trees']["Events"]["branchgroups"]
+
+    nEvet = data['trees']["Events"]["entries"]
+    #fields = set(groups.keys()) - set(groups_ref.keys()) 
+
+   # Find fields that are missing in groups_ref
+    new_groups = set(groups.keys()) - set(groups_ref.keys())
+
+    # Find fields with different subs lengths (i.e. added branches in same table)
+    different_subs_fields = {
+        field for field in groups.keys() & groups_ref.keys()  # Only fields in both
+        if len(groups[field].get("subs", [])) != len(groups_ref[field].get("subs", []))
+    }
+    # Combine both conditions
+    fields = new_groups | different_subs_fields  
+
+    # Extracting 'tot', 'vars', and 'items' for each field
+    result = {}
+    for field in fields:
+        group_data = groups.get(field, {})
+        group_data_ref = groups_ref.get(field, {})
+
+        ## subtract the reference portion
+        if field in different_subs_fields:
+            tot =  float("%.3f"%((group_data.get("tot")-group_data_ref.get("tot"))/nEvet)) 
+            var =  len(group_data.get("subs"))-len(group_data_ref.get("subs"))
+        else:
+            tot =  float("%.3f"%(group_data.get("tot")/nEvet))
+            var =  len(group_data.get("subs"))
+        result[field] = {
+            "tot": tot  ,
+            "vars": var ,
+            "items": float("%.3f"%(group_data.get("entries")/nEvet))
+        }
+
+    result["Full nano"] = {
+            "tot":float("%.3f"%(data_ref['trees']["Events"]['allsize']/nEvet)) 
+    }
+    
+    return result
+
+def display_results(results):
+    """Format and print results as an ASCII table with multi-row headers."""
+    if not results:
+        print("No JSON data found.")
+        return
+
+    # Generate headers
+    file_headers = ["-", "-"]  # First row with file names
+    column_headers = ["Field", "vars"]  # Second row with column labels
+    
+    for file_name, _ in results:
+        file_headers.extend([file_name, "-"] )  # Each file contributes two columns: 'tot' and 'items'
+        column_headers.extend(["size(kb)/evt", "items/evt"])  # Column names per file
+
+    # Collect all unique fields across all files
+    all_fields = {field for _, data in results for field in data.keys()}
+
+    # Prepare table data
+    table = []
+    total_sums = {file_name: 0 for file_name, _ in results}  # Store total sums per file
+    summary_sums = {}  # Store sums for additional summary lines (e.g., DisplacedJet, etc.)
+
+    # List of conditions for dynamic summary rows
+    summary_conditions = [
+        {"name": "DispJet", "pattern": "DispJet"},
+        {"name": "Muon", "pattern": "Muon"},
+        {"name": "MDS", "pattern": "MDS"},
+        #{"name": "cscMDS", "pattern": "cscMDSCluster"},
+        #{"name": "dtMDS", "pattern": "dtMDSCluster"},
+    ]
+
+    for field in sorted(all_fields):  # Sort fields alphabetically
+        if "Full nano" in field: continue
+        row = [field]
+        vars_val = "N/A"
+
+        # Get 'vars' value from the first occurrence of this field
+        for _, data in results:
+            if vars_val == "N/A" and field in data and "vars" in data[field]:
+                vars_val = data[field]["vars"]
+
+        row.append(vars_val)  # Append 'vars' (only once)
+
+        for file_name, data in results:
+            field_data = data.get(field, {})
+            tot = field_data.get("tot", "N/A")
+            items = field_data.get("items", "N/A")
+
+            if tot != "N/A":
+                total_sums[file_name] += float(tot)  # Sum 'tot' values per file
+                #print(file_name,field,tot)
+            # Check for fields matching any summary condition
+                for condition in summary_conditions:
+                    if condition["pattern"] in field:
+                        if condition["name"] not in summary_sums:
+                            summary_sums[condition["name"]] = {file_name: 0 for file_name, _ in results}
+                        print(condition,file_name)
+                        summary_sums[condition["name"]][file_name] += float(tot)  # Sum for matching pattern
+
+            row.extend([tot, items])  # Append 'tot' and 'items' for each file
+
+        table.append(row)
+
+   # Add dynamic summary rows for each condition
+    for condition in summary_conditions:
+        summary_row = [condition["name"], ""]
+        for file_name in summary_sums[condition["name"]]:
+            summary_row.extend(["%.3f"%summary_sums[condition["name"]][file_name], ""])  # Sum only for 'tot' for the condition
+        table.append(summary_row)
+
+    # Add a "Total Sum" row at the bottom
+    total_row = ["Total ExoNano sum", ""]  # No vars value for total row
+    for file_name, _ in results:
+        total_row.extend(["%.3f"%total_sums[file_name], ""])  # Show sum only for 'tot'
+    table.append(total_row)
+    
+    # Add a "full nano" row at the bottom
+    total_row = ["Stock nano sum", ""]  # No vars value for total row
+    for _, data in results:
+        total_row.extend(["%.3f"%data.get("Full nano").get("tot"), ""])  # Show sum only for 'tot'
+    table.append(total_row)
+
+
+    # Insert multi-row headers manually
+    formatted_table = [file_headers] + [column_headers] + table
+
+    # Print table
+    print(tabulate(formatted_table, tablefmt="grid"))
+ 
+if __name__ == "__main__":
+
+    """Process all JSON files in a directory and extract specified fields."""
+    results = []
+    json_files = [  
+                   #("size_EGamma.json", "size_EGamma_ref.json"),
+                   ("size_EGamma_v1.json", "size_EGamma_ref.json"),
+                   #("size_Muon.json","size_Muon_ref.json"),
+                   ("size_Muon_v1.json","size_Muon_ref.json"),
+                   #("size_MDSskim.json","size_MDSskim_ref.json"),
+                   ("size_MDSskim_v1.json","size_MDSskim_ref.json"),
+                   #("size_TT.json","size_TT_ref.json"),
+                   ("size_TT_v1.json","size_TT_ref.json")
+                   #("size_signal.json","size_TT_ref.json")
+                   ]
+    for size_file, ref_file in json_files:
+        parsed_data = parse_json(size_file, ref_file)
+        results.append((size_file, parsed_data))
+
+    display_results(results)

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,36 @@
+EGamma_data='/store/data/Run2023D/EGamma0/AOD/PromptReco-v1/000/370/580/00001/ff70112c-b5a0-4011-b054-a423a3cb1464.root'
+
+#cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$EGamma_data outputTag="EGamma"
+cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$EGamma_data outputTag="EGamma_v1"
+cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$EGamma_data outputTag="EGamma_ref" EXO="FALSE"
+
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_EGamma_ref.root --size size_EGamma_ref.html -j size_EGamma_ref.json
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_EGamma_v1.root --size size_EGamma_v1.html -j size_EGamma_v1.json
+
+TT_MC='/store/mc/Run3Summer23DRPremix/TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/AODSIM/130X_mcRun3_2023_realistic_v14-v2/2550000/0377b97b-92c5-4fad-9f8c-a5e65e528810.root'
+
+cmsRun Run3_2023_PAT_EXONANO_MC.py maxEvents=1000 inputFile=$TT_MC outputTag="TT_4Q_v1" 
+cmsRun Run3_2023_PAT_EXONANO_MC.py maxEvents=1000 inputFile=$TT_MC outputTag="TT_4Q_ref"  EXO="FALSE" 
+
+#$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_MC_TT_4Q.root --size size_TT.html -j size_TT.json
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_MC_TT_4Q_v1.root --size size_TT_v1.html -j size_TT_v1.json
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_MC_TT_4Q_ref.root --size size_TT_ref.html -j size_TT_ref.json
+
+MDSskim="file:/eos/cms/store/user/kakwok/HLT/Commissioning2024/mds_nano/Muon0_EXOskim_0.root"
+
+#cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$MDSskim outputTag="MDSskim" 
+cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$MDSskim outputTag="MDSskim_v1" 
+cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$MDSskim outputTag="MDSskim_ref" EXO="FALSE" 
+#$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_MDSskim.root --size size_MDSskim.html -j size_MDSskim.json
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_MDSskim_v1.root --size size_MDSskim_v1.html -j size_MDSskim_v1.json
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_MDSskim_ref.root --size size_MDSskim_ref.html -j size_MDSskim_ref.json
+
+Muon_data='/store/data/Run2024I/Muon1/AOD/PromptReco-v2/000/386/694/00000/00d3c6c0-84fa-44e3-89c6-55aee9ad8bf1.root'
+
+#cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$Muon_data outputTag="Muon" 
+cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$Muon_data outputTag="Muon_v1" 
+cmsRun Run3_2023_PAT_EXONANO_template_data.py maxEvents=1000 inputFile=$Muon_data outputTag="Muon_ref" EXO="FALSE" 
+
+#$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_Muon.root --size size_Muon.html -j size_Muon.json
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_Muon_v1.root --size size_Muon_v1.html -j size_Muon_v1.json
+$CMSSW_BASE/src/PhysicsTools/NanoAOD/test/inspectNanoFile.py EXONANO_Muon_ref.root --size size_Muon_ref.html -j size_Muon_ref.json


### PR DESCRIPTION
This PR implements additional MDS Run 3 analysis branches.
Instead of using the simple HLT cluster object:  
 - New CSC cluster time and time spread implementation
 - New DT cluster time (using BX from matched RPC hits) 
 - deltaR matching to RPC/DT hits for vetoes
 - constituent rechits for debugging 
 
The overall size increase is 0.1 - 0.7 kb/event, depending on the dataset. 

Before the implementation (The column shows Egamma/Muon/TTbar dataset respectively):
<img width="780" alt="image" src="https://github.com/user-attachments/assets/20c3100c-231a-4d71-8ad9-2feba9af16dd" />
After the implementation:
<img width="835" alt="image" src="https://github.com/user-attachments/assets/c0a71fa9-20c2-4eec-8906-0f2062c59c14" />

Scripts for size measurements are also included. 